### PR TITLE
Fix date conversion mistake

### DIFF
--- a/date.go
+++ b/date.go
@@ -1,8 +1,8 @@
 package poloniex
 
 import (
-	"encoding/binary"
 	"errors"
+	"strconv"
 	"time"
 )
 
@@ -11,8 +11,8 @@ type PoloniexDate struct {
 }
 
 func (pd *PoloniexDate) UnmarshalJSON(data []byte) error {
-	i, err := binary.Varint(data)
-	if err == 0 {
+	i, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
 		return errors.New("Timestamp invalid (can't parse int64)")
 	}
 	pd.Time = time.Unix(i, 0)


### PR DESCRIPTION
I tried to get too fancy on this, a string conversion _is_ what is actually needed, the binary format is not how this is presented o_o 

This fixes the bug

@jyap808 

Signed-off-by: Xavier Sandal <sandalwing@sandalwing.com>