### PR TITLE
fix(volumes): missing case for totalETH

### DIFF
--- a/volume.go
+++ b/volume.go
@@ -29,6 +29,12 @@ func (tc *VolumeCollection) UnmarshalJSON(b []byte) error {
 				return err
 			}
 			tc.TotalBTC = f
+		case "totalETH":
+			f, err := parseJSONFloatString(v)
+			if err != nil {
+				return err
+			}
+			tc.TotalUSDT = f
 		case "totalUSDT":
 			f, err := parseJSONFloatString(v)
 			if err != nil {


### PR DESCRIPTION
Because fields `totalETH` in the switch was missing,  we had this error when getting volumes:
`Error: json: cannot unmarshal string into Go value of type map[string]json.RawMessage`