### PR TITLE
Remove slash from API base url

### DIFF
--- a/poloniex.go
+++ b/poloniex.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	API_BASE = "https://poloniex.com/" // Poloniex API endpoint
+	API_BASE = "https://poloniex.com" // Poloniex API endpoint
 )
 
 // New returns an instantiated poloniex struct


### PR DESCRIPTION
Url slash added twice, second are here: https://github.com/jyap808/go-poloniex/blob/006bc6538cd479f28d4259a4d7855b8cd6258943/client.go#L104