### PR TITLE
Fix ChartData endpoint call

### DIFF
--- a/deposit.go
+++ b/deposit.go
@@ -1,8 +1,8 @@
 package poloniex
 
 import (
-	"time"
 	"encoding/json"
+	"time"
 )
 
 type Deposit struct {

--- a/poloniex.go
+++ b/poloniex.go
@@ -108,7 +108,7 @@ func (b *Poloniex) GetOrderBook(market, cat string, depth int) (orderBook OrderB
 // returned.
 func (b *Poloniex) ChartData(currencyPair string, period int, start, end time.Time) (candles []*CandleStick, err error) {
 	r, err := b.client.do("GET", fmt.Sprintf(
-		"/public?command=returnChartData&currencyPair=%s&period=%d&start=%d&end=%d",
+		"public?command=returnChartData&currencyPair=%s&period=%d&start=%d&end=%d",
 		strings.ToUpper(currencyPair),
 		period,
 		start.Unix(),

--- a/withdrawal.go
+++ b/withdrawal.go
@@ -1,9 +1,9 @@
 package poloniex
 
 import (
-	"time"
 	"encoding/json"
 	"strings"
+	"time"
 )
 
 type Withdrawal struct {


### PR DESCRIPTION
The call to the endpoint are with one more slash, causing this error:

```
panic: Get https://poloniex.com//public?command=returnChartData&currencyPair=BTC_XMR&period=300&start=1508022267&end=1508025867: invalid request :path "//public?command=returnChartData&currencyPair=BTC_XMR&period=300&start=1508022267&end=1508025867"
```

I just removed it.