### PR TITLE
Cancel orders function now works with 32 bit systems

### DIFF
--- a/order.go
+++ b/order.go
@@ -21,7 +21,7 @@ type Orderb struct {
 */
 
 type OpenOrder struct {
-	OrderNumber int     `json:"orderNumber,string"`
+	OrderNumber int64   `json:"orderNumber,string"`
 	Type        string  `json:"type"`
 	Rate        float64 `json:"rate,string"`
 	Amount      float64 `json:"amount,string"`


### PR DESCRIPTION
The error I got: json: cannot unmarshal number .... into Go struct field OpenOrder.orderNumber of type int' for 32 bit systems

This happened for me on the raspberry pi. 
The order number is exceeding the max int32 value. This works on 64 bit systems because golang then regards the int to be 64 bit and not 32 bit

